### PR TITLE
バージョンの修正

### DIFF
--- a/SocketRocket/Resources/Info.plist
+++ b/SocketRocket/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
iTunes Store Operation Failed
> ERROR ITMS-90056: “This bundle Payload/MobCas.app/PlugIns/ScreenCast.appex/Frameworks/SocketRocket.framework is invalid. The Info.plist file is missing the required key: CFBundleVersion.”